### PR TITLE
import os, pandas, and uuid in monitor.py

### DIFF
--- a/baselines/bench/monitor.py
+++ b/baselines/bench/monitor.py
@@ -5,7 +5,10 @@ from gym.core import Wrapper
 import time
 from glob import glob
 import csv
+import os
 import os.path as osp
+import pandas
+import uuid
 import json
 import numpy as np
 


### PR DESCRIPTION
flake8 testing of https://github.com/ml-jku/baselines-rudder on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./baselines/bench/monitor.py:142:55: F821 undefined name 'uuid'
    mon_file = "/tmp/baselines-test-%s.monitor.csv" % uuid.uuid4()
                                                      ^
./baselines/bench/monitor.py:158:20: F821 undefined name 'pandas'
    last_logline = pandas.read_csv(f, index_col=None)
                   ^
./baselines/bench/monitor.py:161:5: F821 undefined name 'os'
    os.remove(mon_file)    ^
3     F821 undefined name 'uuid'
3
```